### PR TITLE
Utils specs

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -19,25 +19,25 @@ module.exports = {
 
   ensureGlobalModules: function (moduleName) {
     try {
-      console.log('Checking for ' + moduleName + ' installation...');
+      logger.log('Checking for ' + moduleName + ' installation...');
       child_process.execSync('npm list -g ' + moduleName);
       child_process.execSync(moduleName + ' -v');
 
     } catch (e) {
       logger.warn(moduleName + ' must be installed globally.');
-      console.log('Would you like to install ' + moduleName + ' now?');
+      logger.log('Would you like to install ' + moduleName + ' now?');
 
       var result = prompt('Yes'.green + ' or ' + 'No: '.red).toLowerCase();
 
       if (result == 'yes') {
-        console.log('Installing ' + moduleName + '...');
+        logger.log('Installing ' + moduleName + '...');
         child_process.execSync('npm install -g ' + moduleName);
         logger.done();
         return true;
       }
 
       if (result == 'no') {
-        console.log('Please install ' + moduleName + ' and run kick again.');
+        logger.log('Please install ' + moduleName + ' and run kick again.');
         return false;
       }
     }

--- a/spec/utils.spec.js
+++ b/spec/utils.spec.js
@@ -1,0 +1,29 @@
+var kick          = __dirname + '/../../bin/kick ';
+var child_process = require('child_process');
+var utils         = require('../lib/utils');
+var logger        = require('../lib/logger');
+
+ddescribe('utils module methods', function () {
+
+  beforeEach(function () {
+    spyOn(child_process, 'execSync');
+    spyOn(logger, 'log');
+    spyOn(logger, 'warn');
+  });
+
+  it('should log a message to the console', function () {
+    utils.ensureGlobalModules('bower');
+    expect(logger.log).toHaveBeenCalledWith('Checking for bower installation...');
+  });
+
+  it('should delegate to a "npm list" command with child process', function () {
+    utils.ensureGlobalModules('bower');
+    expect(child_process.execSync).toHaveBeenCalledWith('npm list -g bower');
+  });
+
+  it('should try to run the provided module "-v" command', function () {
+    utils.ensureGlobalModules('bower');
+    expect(child_process.execSync).toHaveBeenCalledWith('bower -v');
+  });
+
+});


### PR DESCRIPTION
- refactoring utils.ensureGlobalModules method to use logger.log instead of console.log.
- creating a spec file to contians specs for the utils class