### PR TITLE
Fix NodeJS 4 check

### DIFF
--- a/bin/kick
+++ b/bin/kick
@@ -10,7 +10,7 @@ var nodeVersion   = child_process.execSync('node -v').toString();
 var colors        = require('colors');
 
 function ensureNodeVersion() {
-  if (!nodeVersion.match('v4.0')) {
+  if (!nodeVersion.match('v4\.\d')) {
     console.log('⚠ '.red + 'You need nodejs '.yellow + '>= 4.0'.white + ' in order to use angular'.yellow);
     process.exit(0);
   }

--- a/bin/kick
+++ b/bin/kick
@@ -10,7 +10,7 @@ var nodeVersion   = child_process.execSync('node -v').toString();
 var colors        = require('colors');
 
 function ensureNodeVersion() {
-  if (!nodeVersion.match('v4\.\d')) {
+  if (!nodeVersion.match(/v4\.\d/)) {
     console.log('⚠ '.red + 'You need nodejs '.yellow + '>= 4.0'.white + ' in order to use angular'.yellow);
     process.exit(0);
   }


### PR DESCRIPTION
In the current check it is hard coded to nodeJS 4.0

NodeJS 4.1 is the current version and you cannot use kick as the version check fails.