### PR TITLE
Improve if-env directive, does not render element under wrong env

### DIFF
--- a/templates/angular/app/app/directives/if_env.js
+++ b/templates/angular/app/app/directives/if_env.js
@@ -1,5 +1,15 @@
 export function ifEnv(ENV) {
-  return function (scope, element, attrs) {
-    if (ENV !== attrs.ifEnv) { element.remove(); }
+  return {
+    restrict: 'A',
+    priority: 600,
+    transclude: 'element',
+    terminal: true,
+    link: function(scope, element, attrs, ctrl, $transclude) {
+      if (ENV === attrs.ifEnv) {
+        $transclude(function (clone) {
+          element.after(clone);
+        });
+      }
+    }
   }
 }

--- a/templates/angular/app/app/directives/if_env.js
+++ b/templates/angular/app/app/directives/if_env.js
@@ -4,11 +4,9 @@ export function ifEnv(ENV) {
     priority: 600,
     transclude: 'element',
     terminal: true,
-    link: function(scope, element, attrs, ctrl, $transclude) {
+    link(scope, element, attrs, ctrl, $transclude) {
       if (ENV === attrs.ifEnv) {
-        $transclude(function (clone) {
-          element.after(clone);
-        });
+        $transclude((clone) => element.after(clone));
       }
     }
   }

--- a/templates/angular/app/test/unit/directives/if_env.spec.js
+++ b/templates/angular/app/test/unit/directives/if_env.spec.js
@@ -5,19 +5,19 @@ describe('ifEnv Directive', function () {
 
   beforeEach(angular.mock.module('%APP_NAME%.config', '%APP_NAME%.directives'));
 
-  beforeEach(angular.mock.inject(function ($compile) {
+  beforeEach(angular.mock.inject(function ($compile, $rootScope) {
     testElement = angular.element('<div><div if-env="test">Contents</div></div>');
-    testElement = $compile(testElement)({});
+    testElement = $compile(testElement)($rootScope);
 
     buildElement = angular.element('<div><div if-env="production">Contents</div></div>');
-    buildElement = $compile(buildElement)({});
+    buildElement = $compile(buildElement)($rootScope);
   }));
 
-  it('should show element under correct environment', function () {
+  it('should render element under correct environment', function () {
     expect(testElement.html()).toContain('Contents');
   });
 
-  it('should destroy element under wrong environment', function () {
+  it('should not render element under wrong environment', function () {
     expect(buildElement.html()).not.toContain('Contents');
   });
 });


### PR DESCRIPTION
The if-env directive was modified to a behaviour closer to ng-if
The entire element is transcluded and if the ENV matches it appends
it self back to the DOM.

Priority chosen for this directive is the same as ng-if (600).
It also lacks the watch functionallity of ng-if as there is no reason
the ENV variable will change on runtime.